### PR TITLE
Remove SourceLink package

### DIFF
--- a/AzureIPNetworks/AzureIPNetworks.csproj
+++ b/AzureIPNetworks/AzureIPNetworks.csproj
@@ -36,10 +36,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 


### PR DESCRIPTION
This is redundant now as it's built in to the .NET 8 SDK.